### PR TITLE
Create a rake task for fetching events

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,0 +1,6 @@
+namespace :events do
+  desc "Fetch all events, creating or updating in our DB"
+  task fetch: :environment do
+    DataRequest.call
+  end
+end


### PR DESCRIPTION
Closes #3 

Adds a rake task `bin/rake events:fetch` that we can use with Heroku's [scheduler](https://devcenter.heroku.com/articles/scheduler)